### PR TITLE
Update to column handling when moving between rows

### DIFF
--- a/minui-keyboard.c
+++ b/minui-keyboard.c
@@ -135,7 +135,19 @@ void handle_keyboard_input(struct AppState *state)
     {
         if (state->keyboard.row > 0)
         {
-            state->keyboard.col += calculate_column_offset(current_layout, state->keyboard.row, state->keyboard.row - 1);
+            int offset = calculate_column_offset(current_layout, state->keyboard.row, state->keyboard.row - 1);
+            if (state->keyboard.row == 4 && count_row_length(current_layout, state->keyboard.row - 1) % 2 == 0)
+            {
+                if (state->keyboard.col == 0)
+                {
+                    offset -= 1;
+                }
+                else if (state->keyboard.col == 2)
+                {
+                    offset += 1;
+                }
+            }
+            state->keyboard.col += offset;
             state->keyboard.row--;
         }
         else
@@ -160,7 +172,17 @@ void handle_keyboard_input(struct AppState *state)
     {
         if (state->keyboard.row < max_row - 1)
         {
-            state->keyboard.col += calculate_column_offset(current_layout, state->keyboard.row, state->keyboard.row + 1);
+            int offset = calculate_column_offset(current_layout, state->keyboard.row, state->keyboard.row + 1);
+            int this_row_length = count_row_length(current_layout, state->keyboard.row);
+            
+            if (state->keyboard.row + 1 == 4 && this_row_length % 2 == 0)
+            {
+                if (state->keyboard.col > (this_row_length / 2) - 1)
+                {
+                    offset -= 1;
+                }
+            }
+            state->keyboard.col += offset;
             state->keyboard.row++;
             while (state->keyboard.col >= 0 && current_layout[state->keyboard.row][state->keyboard.col][0] == '\0')
             {

--- a/minui-keyboard.c
+++ b/minui-keyboard.c
@@ -89,6 +89,24 @@ int max(int a, int b)
     return (a > b) ? a : b;
 }
 
+// count_row_length returns the number of non-empty characters in a keyboard row
+int count_row_length(const char *(*layout)[14], int row) {
+    int length = 0;
+    for (int i = 0; i < 14; i++) {
+        if (layout[row][i][0] != '\0') {
+            length++;
+        }
+    }
+    return length;
+}
+
+// calculate_column_offset returns how much to adjust the column when moving between rows
+int calculate_column_offset(const char *(*layout)[14], int from_row, int to_row) {
+    int from_length = count_row_length(layout, from_row);
+    int to_length = count_row_length(layout, to_row);
+    return (to_length - from_length) / 2;
+}
+
 // handle_keyboard_input interprets keyboard input events and mutates app state
 void handle_keyboard_input(struct AppState *state)
 {
@@ -117,10 +135,12 @@ void handle_keyboard_input(struct AppState *state)
     {
         if (state->keyboard.row > 0)
         {
+            state->keyboard.col += calculate_column_offset(current_layout, state->keyboard.row, state->keyboard.row - 1);
             state->keyboard.row--;
         }
         else
         {
+            state->keyboard.col += calculate_column_offset(current_layout, 0, max_row - 1);
             state->keyboard.row = max_row - 1;
             while (state->keyboard.col >= 0 && current_layout[state->keyboard.row][state->keyboard.col][0] == '\0')
             {
@@ -140,6 +160,7 @@ void handle_keyboard_input(struct AppState *state)
     {
         if (state->keyboard.row < max_row - 1)
         {
+            state->keyboard.col += calculate_column_offset(current_layout, state->keyboard.row, state->keyboard.row + 1);
             state->keyboard.row++;
             while (state->keyboard.col >= 0 && current_layout[state->keyboard.row][state->keyboard.col][0] == '\0')
             {
@@ -156,6 +177,7 @@ void handle_keyboard_input(struct AppState *state)
         }
         else
         {
+            state->keyboard.col += calculate_column_offset(current_layout, max_row - 1, 0);
             state->keyboard.row = 0;
         }
     }


### PR DESCRIPTION
I made some changes to help keep the cursor moving as expected when going between rows.

The issue that still exists in this fix but in a more specific place:  the bottom row 'keys' are much wider but are still treated the same as the single letter keys in my change.  Because of this, when moving between the bottom row and the lowest row with letters, even though 'b' and 'n' are directly above 'space', moving down from 'n' shifts over to 'enter' rather than directly down.  I considered targeting this further but it felt like anything to handle this specifically might make it a nightmare if/when a digits layout is implemented.

fixes #4 