### PR TITLE
feat: allow writing output to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ minui-keyboard > output.txt
 # capture output to a variable for use in a shell script
 output=$(minui-keyboard)
 
+# you can also specify a location to write to
+# the internal minui sdk sometimes writes to stdout
+# depending on platform, so this may be useful
+minui-keyboard --write-location file.txt
+
 # specify a title for the keyboard page
 # by default, the title is empty
 minui-keyboard --title "Some Header"


### PR DESCRIPTION
On some supported MinUI platforms, the internal SDK writes to stdout, causing issues with capturing and parsing the output. Since we don't control the SDK and silencing it is difficult, this PR provides the ability to write the the keyboard output to a file for later parsing.